### PR TITLE
Removed _IdDict

### DIFF
--- a/sympy2jax/__init__.py
+++ b/sympy2jax/__init__.py
@@ -15,4 +15,4 @@
 from .sympy_module import SymbolicModule
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"


### PR DESCRIPTION
The use of _IdDict was causing issues with symbol lookups, as we can
obtain strings in more than one way. (Which I knew when I originally
wrote this, but for some reason thought we avoided.)

There was a good reason for looking things up by identity, namely that
it makes most sense to look up each AbstractNode by identity. (As
they're not otherwise hashable in any meaningful way.) So we've switched
to doing that just for AbstractNode instead.